### PR TITLE
.gitignore: ignore .deps directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.deps
 zoneinfo
 Makefile
 Makefile.in


### PR DESCRIPTION
Building cyrus-timezones from git leaves the local repository in a dirty state, because the build creates a "guesstz/.deps/" directory with Makefile snippets containing dependencies, which is neither committed nor ignored.

On cyrus-imapd we ignore any file or directory called ".deps"; this does the same for cyrus-timezones.